### PR TITLE
update integration test for metrics

### DIFF
--- a/spring5-micrometer/src/main/resources/application.properties
+++ b/spring5-micrometer/src/main/resources/application.properties
@@ -2,9 +2,4 @@
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
 management.metrics.web.server.auto-time-requests=true
 
-# 2.4.1 requires
-management.metrics.export.defaults.enabled=true
-management.metrics.export.prometheus.enabled=true
-#logging.level.org.springframework.boot=DEBUG
-
 logging.level.dev.ebullient.dnd=INFO

--- a/spring5-micrometer/src/test/java/dev/ebullient/dnd/MainTest.java
+++ b/spring5-micrometer/src/test/java/dev/ebullient/dnd/MainTest.java
@@ -16,6 +16,7 @@ package dev.ebullient.dnd;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,6 +27,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import dev.ebullient.dnd.combat.client.CombatMetrics;
 
 @SpringBootTest(classes = Main.class)
+@AutoConfigureMetrics
 @ExtendWith(SpringExtension.class)
 @AutoConfigureWebTestClient
 public class MainTest {


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#metrics-export-in-integration-tests

> Metrics export in integration tests
> @SpringBootTest no longer configures available monitoring systems and only provide the in-memory MeterRegistry. If you were exporting metrics as part of an integration test, you can add @AutoConfigureMetrics to your test to restore the previous behaviour.

